### PR TITLE
Remove dependency on pytest-runner

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,6 @@ requirements:
   host:
     - python
     - pip
-    - pytest-runner
   run:
     - python
     - pyyaml


### PR DESCRIPTION
Recent PRs against OmegaConf's [master branch](https://github.com/omry/omegaconf/pull/800) and [2.1_branch](https://github.com/omry/omegaconf/pull/809) have removed OmegaConf's dependency on the deprecated [`pytest-runner`](https://pypi.org/project/pytest-runner/) package.
I believe that at some point it should be safe to remove the dependency from this repo's meta.yaml file.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
