### PR TITLE
omegaconf v2.2.3, skipping failing tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @maresb @benjaminrwilson @mdraw @omry
+* @benjaminrwilson @maresb @mdraw @omry

--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ Feedstock Maintainers
 =====================
 
 * [@benjaminrwilson](https://github.com/benjaminrwilson/)
+* [@maresb](https://github.com/maresb/)
 * [@mdraw](https://github.com/mdraw/)
 * [@omry](https://github.com/omry/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ test:
     - tests
   commands:
     - pip check
-    - pytest --ignore tests/test_pydev_resolver_plugin.py
+    - pytest --ignore tests/test_pydev_resolver_plugin.py --ignore tests\structured_conf\test_structured_config.py --ignore tests\test_utils.py
 
 about:
   home: https://github.com/omry/omegaconf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
-
 {% set name = "omegaconf" %}
-{% set version = "2.2.2" %}
+{% set version = "2.2.3" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +7,7 @@ package:
 
 source:
   url: https://github.com/omry/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 10a89b5cb81887d68137b69a7c5c046a060e2239af4e37f20c3935ad2e5fd865
+  sha256: 9586b6623d4abf514979612f987261971a58da2dc7a9224bebd017848c9ad80a
 
 
 build:


### PR DESCRIPTION
Supersedes #35 which was closed when I recreated my fork (I originally forked from autotick-bot).

## The plan (copied from https://github.com/conda-forge/omegaconf-feedstock/pull/35#issuecomment-1245166512)

Now that #34 (Arch migrator) is ready, it will conflict with #32 (omegaconf v2.2.3, skip failing tests). This simply rebases #32 on #34. Thus the plan I would recommend is as follows, where we execute steps 1 and 2 now:

1. ~Merge #34 into `main` to rebuild v2.2.2 for aarch64 (ARM64)~ :heavy_check_mark: 
2. ~Merge this into `main` to make a build for v2.2.3, skipping the broken tests (see https://github.com/omry/omegaconf/pull/1002)~ :heavy_check_mark: 
3. Release upstream v2.2.4 whenever it's ready, including https://github.com/omry/omegaconf/pull/1002
4. Wait for autotick-bot to make a PR for v2.2.4, without merging it yet
5. Merge #33 into the autotick-bot PR to reenable the broken tests which I skipped in order to build v2.2.3.
6. Merge the autotick-bot PR into main once all tests are passing to get a clean build of v2.2.4.


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
