### PR TITLE
FOR v2.2.4: reenable temporarily-skipped tests

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ test:
     - tests
   commands:
     - pip check
-    - pytest --ignore tests/test_pydev_resolver_plugin.py --ignore tests\structured_conf\test_structured_config.py --ignore tests\test_utils.py
+    - pytest --ignore tests/test_pydev_resolver_plugin.py
 
 about:
   home: https://github.com/omry/omegaconf


### PR DESCRIPTION
Merge this into the autotick-bot PR for v2.2.4 to reenable tests which were disabled in #38.

For context and a step-by-step plan, see the description in #38.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
